### PR TITLE
Fix type annotation that impedes compilation

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -155,7 +155,7 @@ where
 
 /// Loads a PEM formatted certificate signing request (CSR) from
 /// a file and returns it as `openssl::X509Req`.
-pub fn load_csr_from_file(path: &str) -> Result<X509Req, Error> {
+pub fn load_csr_from_file(path: &str) -> Result<X509Req> {
     let bytes = std::fs::read(path)?;
 
     Ok(X509Req::from_pem(&bytes)?)


### PR DESCRIPTION
I think this is a leftover merge artifact. But without this patch, the current main branch wouldn't compile. It would make sense to add a CI for testing such things.