### PR TITLE
Allow For Existing Server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 openssl = { version = "0.10", features = ["vendored"] }
 base64 = "0.13.0"
 rouille = "3.0.0"
-clap = "3.0.0-beta.2"
+clap = "3.0.0-beta.5"
 flexi_logger = "0.17.1"
 log = "0.4.14"
 thiserror = "1.0"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,11 +1,11 @@
 use acme_rs::{
     generate_cert_for_domain,
     util::{
-        generate_rsa_keypair, load_csr_from_file, load_keys_from_file, save_certificates,
-        save_keypair,
+        check_for_existing_server, generate_rsa_keypair, load_csr_from_file, load_keys_from_file,
+        save_certificates, save_keypair,
     },
 };
-use clap::Clap;
+use clap::{IntoApp, Parser};
 use flexi_logger::Logger;
 use log::info;
 
@@ -14,7 +14,7 @@ const LETS_ENCRYPT_SERVER: &str = "https://acme-v02.api.letsencrypt.org/director
 const LETS_ENCRYPT_STAGING: &str = "https://acme-staging-v02.api.letsencrypt.org/directory";
 
 /// An acme client (RFC8555) written in the rust programming language
-#[derive(Clap)]
+#[derive(Parser)]
 #[clap(
     version = "0.1.0",
     author = "Bastian Kersting <bastian@cmbt.de>, Tobias Karius <tobias.karius@yahoo.de>, Elena Lilova <elena.lilova@gmx.de>, Dominik Jantschar <dominik.jantschar@web.de>"
@@ -35,6 +35,9 @@ struct Opts {
     /// The ACME server's URL
     #[clap(short, long)]
     server: Option<String>,
+    /// Initialize a standalone web server if there is not one already using port 80.
+    #[clap(long)]
+    standalone: bool,
     /// An optional path to a PEM formatted Certificate Signing Request (CSR)
     #[clap(long)]
     csr_path: Option<String>,
@@ -46,6 +49,7 @@ struct Opts {
 fn main() {
     // parse the cmd arguments
     let opts: Opts = Opts::parse();
+    let mut app = Opts::into_app();
 
     if opts.verbose {
         // setup the logger if necessary
@@ -56,11 +60,10 @@ fn main() {
     }
 
     if opts.csr_path.is_some() && (opts.private_key.is_none() || opts.public_key.is_none()) {
-        clap::Error::with_description(
-            r#"Error! If you provide a CSR you must also specify the keypair
-                        that signed the CSR via --private-key and --public-key"#
-                .to_owned(),
+        app.error(
             clap::ErrorKind::ArgumentConflict,
+            r#"Error! If you provide a CSR you must also specify the keypair
+                        that signed the CSR via --private-key and --public-key"#,
         )
         .exit();
     }
@@ -68,11 +71,12 @@ fn main() {
     // create a new key pair or otherwise read from a file
     let keypair_for_cert = match (opts.private_key.as_ref(), opts.public_key.as_ref()) {
         (Some(priv_path), Some(pub_path)) => load_keys_from_file(priv_path, pub_path),
-        (Some(_), None) | (None, Some(_)) => clap::Error::with_description(
-            "Error! Provide both a public and a private key!".to_owned(),
-            clap::ErrorKind::ArgumentConflict,
-        )
-        .exit(),
+        (Some(_), None) | (None, Some(_)) => app
+            .error(
+                clap::ErrorKind::ArgumentConflict,
+                "Error! Provide both a public and a private key!",
+            )
+            .exit(),
 
         (None, None) => generate_rsa_keypair(),
     }
@@ -88,6 +92,14 @@ fn main() {
         info!("Successfully loaded CSR");
     }
 
+    if opts.standalone && check_for_existing_server().unwrap_or_default() {
+        app.error(
+            clap::ErrorKind::DisplayHelp,
+            "Error! Provided the standalone option with a process already listening on port 80",
+        )
+        .exit();
+    }
+
     // get the certificate
     let cert_chain = match opts.server {
         Some(url) => generate_cert_for_domain(
@@ -96,6 +108,7 @@ fn main() {
             opts.domain,
             url,
             opts.email,
+            opts.standalone,
             opts.verbose,
         ),
         None => generate_cert_for_domain(
@@ -104,6 +117,7 @@ fn main() {
             opts.domain,
             LETS_ENCRYPT_SERVER.to_owned(),
             opts.email,
+            opts.standalone,
             opts.verbose,
         ),
     }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -92,7 +92,7 @@ fn main() {
         info!("Successfully loaded CSR");
     }
 
-    if opts.standalone && check_for_existing_server().unwrap_or_default() {
+    if opts.standalone && check_for_existing_server() {
         app.error(
             clap::ErrorKind::DisplayHelp,
             "Error! Provided the standalone option with a process already listening on port 80",

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,6 +70,8 @@ pub enum Error {
     FromIoError(#[from] io::Error),
     #[error("Currently just http challenges are allowed, so this error is raised if no http challenge is present")]
     NoHttpChallengePresent,
+    #[error("There was no web server found")]
+    NoWebServer,
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,16 +20,18 @@
 //! This method is also used by the binary cli that ships with this crate. Usage instructions for the cli and information about the project in general can be found [here](https://github.com/kariustobias/acme-rs).
 //!
 //! ## Example
-//! ```rust
+//! ```ignore,rust
 //! use acme_rs::{generate_cert_for_domain, util::{generate_rsa_keypair, save_certificates, save_keypair}};
 //!
 //! // create a keypair and request the certificate for it
 //! let keypair = generate_rsa_keypair().expect("Error during key creation");
 //! let cert_chain = generate_cert_for_domain(
 //!            &keypair,
+//!            None,
 //!            "www.example.org",
 //!            "https://acme-v02.api.letsencrypt.org/directory",
 //!            "max@mustermann.de",
+//!            false,
 //!            false,
 //!        ).expect("Error while requesting the certificate.")
 //!
@@ -65,16 +67,18 @@ const KEY_WIDTH: u32 = 2048;
 /// used to sign the certificate signing request (CSR). In case a pre loaded CSR is passed in, the keypair
 /// needs to be the same as the one that signed the CSR.
 /// # Example
-/// ```rust
+/// ```ignore,rust
 /// use acme_rs::{generate_cert_for_domain, util::{generate_rsa_keypair, save_certificates, save_keypair}};
 ///
 /// // create a keypair and request the certificate for it
 /// let keypair = generate_rsa_keypair().expect("Error during key creation");
 /// let cert_chain = generate_cert_for_domain(
 ///            &keypair,
+///            None,
 ///            "www.example.org",
 ///            "https://acme-v02.api.letsencrypt.org/directory",
 ///            "max@mustermann.de",
+///            false,
 ///            false,
 ///        ).expect("Error while requesting the certificate.")
 ///
@@ -87,6 +91,7 @@ pub fn generate_cert_for_domain<T: AsRef<str>>(
     domain: T,
     server: T,
     email: T,
+    standalone: bool,
     verbose: bool,
 ) -> Result<Certificate, Error> {
     // this keypair is used for authentificating the requests, but does not matter afterwards
@@ -127,8 +132,12 @@ pub fn generate_cert_for_domain<T: AsRef<str>>(
     }
 
     // complete the challenge and save the nonce that's needed for further authentification
-    let new_nonce =
-        challenge.complete_http_challenge(&client, &new_acc.account_location, &keypair)?;
+    let new_nonce = challenge.complete_http_challenge(
+        &client,
+        &new_acc.account_location,
+        &keypair,
+        standalone,
+    )?;
     if verbose {
         info!("Succesfully completed the http challenge");
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -389,7 +389,7 @@ impl ChallengeAuthorisation {
                     }
                 });
             });
-        } else if check_for_existing_server()? {
+        } else if check_for_existing_server() {
             const WEB_ROOT: &str = "/var/www/html";
 
             let full_path = Path::new(WEB_ROOT).join(CHALLENGE_PATH);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,7 @@
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+
 use core::fmt::Debug;
 use openssl::{
     hash::MessageDigest,
@@ -13,7 +17,10 @@ use serde_json::json;
 
 use crate::{
     error::{Error, Result},
-    util::{b64, extract_payload_and_nonce, extract_payload_location_and_nonce, jwk, jws},
+    util::{
+        b64, check_for_existing_server, extract_payload_and_nonce,
+        extract_payload_location_and_nonce, jwk, jws,
+    },
 };
 
 pub type Nonce = String;
@@ -327,6 +334,7 @@ impl ChallengeAuthorisation {
         client: &Client,
         account_url: &str,
         p_key: &Rsa<Private>,
+        standalone: bool,
     ) -> Result<Nonce> {
         let http_challenge = self
             .challenges
@@ -340,6 +348,7 @@ impl ChallengeAuthorisation {
             self.nonce,
             account_url,
             p_key,
+            standalone,
         )
     }
 
@@ -350,7 +359,10 @@ impl ChallengeAuthorisation {
         nonce: Nonce,
         acc_url: &str,
         private_key: &Rsa<Private>,
+        standalone: bool,
     ) -> Result<Nonce> {
+        const CHALLENGE_PATH: &str = "/.well-known/acme-challenge";
+
         let thumbprint = jwk(private_key)?;
         let mut hasher = Sha256::new();
         hasher.update(&thumbprint.to_string().into_bytes());
@@ -366,17 +378,27 @@ impl ChallengeAuthorisation {
             private_key,
         )?;
 
-        std::thread::spawn(|| {
-            rouille::start_server("0.0.0.0:80", move |request| {
-                if request.raw_url()
-                    == format!("/.well-known/acme-challenge/{}", challenge_infos.token)
-                {
-                    rouille::Response::text(challenge_content.clone())
-                } else {
-                    rouille::Response::empty_404()
-                }
+        if standalone {
+            std::thread::spawn(|| {
+                rouille::start_server("0.0.0.0:80", move |request| {
+                    if request.raw_url() == format!("{}/{}", CHALLENGE_PATH, challenge_infos.token)
+                    {
+                        rouille::Response::text(challenge_content.clone())
+                    } else {
+                        rouille::Response::empty_404()
+                    }
+                });
             });
-        });
+        } else if check_for_existing_server()? {
+            const WEB_ROOT: &str = "/var/www/html";
+
+            let full_path = Path::new(WEB_ROOT).join(CHALLENGE_PATH);
+            fs::create_dir_all(full_path.clone())?;
+            let mut output = File::create(full_path.join(challenge_infos.token))?;
+            write!(output, "{}", challenge_content)?;
+        } else {
+            return Err(Error::NoWebServer);
+        }
         std::thread::sleep(std::time::Duration::from_secs(5));
         Ok(result)
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 use base64::encode_config;
 use openssl::{
     hash::MessageDigest,
@@ -16,6 +18,17 @@ use crate::{
     KEY_WIDTH,
 };
 
+/// Check if a process if using port 80. A return value of false means there wasn't a process
+/// found.
+pub fn check_for_existing_server() -> Result<bool> {
+    // If it was unsuccessful (i.e. exit code 1), then nothing is currently using that port.
+    Ok(Command::new("lsof")
+        .arg("-i")
+        .arg(":80")
+        .status()?
+        .success())
+}
+
 /// Generates a `RSA` private key.
 pub(crate) fn generate_rsa_key() -> Result<Rsa<Private>> {
     Ok(Rsa::generate(KEY_WIDTH)?)
@@ -32,7 +45,7 @@ pub fn generate_rsa_keypair() -> Result<(Rsa<Private>, Rsa<Public>)> {
 
 /// Builds a json web key `JWK` (RFC7517) for a RSA private key.
 /// # Example
-/// ```rust
+/// ```ignore,rust
 /// use acme_rs::util::jwk;
 /// use openssl::Rsa;
 ///
@@ -54,7 +67,7 @@ pub fn jwk(private_key: &Rsa<Private>) -> Result<serde_json::Value> {
 /// Constructs a json web signature `JWS` (RFC7515) in the flattened `JSON` form for a specified
 /// payload. This involves signing the JWS with the RS256 algorithm.
 /// # Example
-/// ```rust
+/// ```ignore,rust
 /// use acme_rs::util::jws;
 /// use serde_json::json;
 /// use openssl::Rsa;
@@ -155,7 +168,7 @@ where
 
 /// Loads a PEM formatted certificate signing request (CSR) from
 /// a file and returns it as `openssl::X509Req`.
-pub fn load_csr_from_file(path: &str) -> Result<X509Req, Error> {
+pub fn load_csr_from_file(path: &str) -> Result<X509Req> {
     let bytes = std::fs::read(path)?;
 
     Ok(X509Req::from_pem(&bytes)?)

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use std::process::Command;
+use std::net::TcpStream;
 
 use base64::encode_config;
 use openssl::{
@@ -20,13 +20,18 @@ use crate::{
 
 /// Check if a process if using port 80. A return value of false means there wasn't a process
 /// found.
-pub fn check_for_existing_server() -> Result<bool> {
-    // If it was unsuccessful (i.e. exit code 1), then nothing is currently using that port.
-    Ok(Command::new("lsof")
-        .arg("-i")
-        .arg(":80")
-        .status()?
-        .success())
+pub fn check_for_existing_server() -> bool {
+    // These will parse so it's okay to unwrap here.
+    let addrs = [
+        "0.0.0.0:80".parse().unwrap(),
+        "127.0.0.1:80".parse().unwrap(),
+    ];
+
+    if let Ok(_) = TcpStream::connect(&addrs[..]) {
+        true
+    } else {
+        false
+    }
 }
 
 /// Generates a `RSA` private key.


### PR DESCRIPTION
I adjusted a few other items in this PR as well.

- Updated the `clap` beta version.
- Changed the binary error handling to get rid of the deprecated error reporting as suggested by `clap`.
- Added a `--standalone` option.
- Added a new error type called `NoWebServer`.
- Adjusted the documented examples so `cargo test` passes.
- Write files into a well known web root if the user doesn't specify `--standalone` and has a web server running.
- Changed the return type for `load_csr_from_file` to use the type alias.

I hope this is what you had in mind!

Closes #20 